### PR TITLE
Use fixed-size serial read frames

### DIFF
--- a/Scripts/serial_receiver.py
+++ b/Scripts/serial_receiver.py
@@ -2,21 +2,27 @@ import argparse
 import serial
 
 
-def main(port: str, baudrate: int) -> None:
-    """Read lines from the serial port and print them."""
-    with serial.Serial(port, baudrate, timeout=1) as ser:
+def main(port: str, baudrate: int, frame_size: int) -> None:
+    """Read fixed-size frames from the serial port and print them."""
+    with serial.Serial(port, baudrate) as ser:
+        buffer = bytearray(frame_size)
         try:
             while True:
-                line = ser.readline().decode("utf-8", errors="ignore").strip()
-                if line:
-                    print(line)
+                bytes_read = ser.readinto(buffer)
+                if bytes_read:
+                    print(buffer[:bytes_read].decode("utf-8", errors="ignore"))
         except KeyboardInterrupt:
             pass
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Receive and print sensor data from serial port")
+    parser = argparse.ArgumentParser(
+        description="Receive and print sensor data from serial port"
+    )
     parser.add_argument("--port", default="/dev/ttyACM0", help="Serial port to open")
     parser.add_argument("--baudrate", type=int, default=9600, help="Baud rate for the serial connection")
+    parser.add_argument(
+        "--frame-size", type=int, default=64, help="Number of bytes to read per frame"
+    )
     args = parser.parse_args()
-    main(args.port, args.baudrate)
+    main(args.port, args.baudrate, args.frame_size)


### PR DESCRIPTION
## Summary
- Read sensor data in fixed-size frames using `readinto` for efficiency
- Remove serial timeout and expose frame size as CLI option

## Testing
- `python -m py_compile Scripts/serial_receiver.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a486d4a5f483289724e3f020248d29