### PR TITLE
Move sensor data send to timer and reduce loop delay

### DIFF
--- a/Scripts/main.cpp
+++ b/Scripts/main.cpp
@@ -69,6 +69,7 @@ volatile float boxHum;
 IntervalTimerEx mhdTimer;
 IntervalTimerEx sensorTimer;
 IntervalTimerEx currentSensorTimer;
+IntervalTimerEx sendDataTimer;
 
 void readSensors()
 {
@@ -225,12 +226,13 @@ void setup()
   mhdTimer.begin([] {generalTeensy.setMHDmode(); }, generalTeensy.intervalEnableMHD);
   sensorTimer.begin([] {readSensors(); }, sensorReadInterval);
   currentSensorTimer.begin([] {readCurrent(); }, currentReadInterval);
+  sendDataTimer.begin([] {sendSensorData(); }, currentReadInterval);
 
 }
 
 void loop()
 {
-  sendSensorData();
-  delay(1000);
+  // Main loop intentionally left light; data transmission is handled by timer.
+  delay(1);
 }
 


### PR DESCRIPTION
## Summary
- Add dedicated timer to send sensor data at sampling rate
- Remove 1-second delay from main loop, keeping it responsive

## Testing
- `g++ Scripts/main.cpp -c` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a486d1935083288a53c1a0fa10d4e4