### PR TITLE
Add timer for sensor data transmission and streamline loop

### DIFF
--- a/Scripts/main.cpp
+++ b/Scripts/main.cpp
@@ -67,6 +67,7 @@ volatile float boxHum;
 IntervalTimerEx mhdTimer;
 IntervalTimerEx sensorTimer;
 IntervalTimerEx currentSensorTimer;
+IntervalTimerEx sendTimer;
 
 void readSensors() {
   sensors_event_t accel;
@@ -216,9 +217,9 @@ void setup() {
                  generalTeensy.intervalEnableMHD);
   sensorTimer.begin([] { readSensors(); }, sensorReadInterval);
   currentSensorTimer.begin([] { readCurrent(); }, currentReadInterval);
+  sendTimer.begin([] { sendSensorData(); }, sensorReadInterval);
 }
 
 void loop() {
-  sendSensorData();
-  delay(1000);
+  delay(1);
 }


### PR DESCRIPTION
## Summary
- add sendTimer to schedule sensor data transmission alongside existing timers
- remove blocking 1-second delay in main loop to improve responsiveness

## Testing
- `g++ -std=c++17 -fsyntax-only Scripts/main.cpp` *(fails: MQ8.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a489556a7c8328a8ba4c8c8c2e6381