### PR TITLE
Increase telemetry baud rate to 5 Mbps

### DIFF
--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -1,0 +1,9 @@
+# Project Notes
+
+## Serial Baud Rate
+
+- The telemetry link now uses a baud rate of **5,000,000 bps** for higher throughput.
+- Ensure the microcontroller and host machine both use this baud rate (see `Scripts/main.cpp` and `Scripts/serial_receiver.py`).
+- Teensy 4.x hardware UART derives from a 24 MHz clock with a minimum oversampling ratio of 4, allowing baud rates up to 6 Mbit/s, so 5 Mbit/s is within spec.
+- Use short, well‑shielded wires and verify that USB‑serial adapters and peripherals can reliably handle 5 Mbit/s.
+- If errors occur, lower the baud rate or improve wiring quality.

--- a/Scripts/main.cpp
+++ b/Scripts/main.cpp
@@ -188,7 +188,8 @@ void sendSensorData() {
 }
 
 void setup() {
-  Serial.begin(9600);
+  // Configure serial port for high-speed telemetry (5 Mbps)
+  Serial.begin(5000000);
   while (!Serial) {
   }
   delay(200);

--- a/Scripts/serial_receiver.py
+++ b/Scripts/serial_receiver.py
@@ -20,7 +20,9 @@ if __name__ == "__main__":
         description="Receive and print sensor data from serial port"
     )
     parser.add_argument("--port", default="/dev/ttyACM0", help="Serial port to open")
-    parser.add_argument("--baudrate", type=int, default=9600, help="Baud rate for the serial connection")
+    parser.add_argument(
+        "--baudrate", type=int, default=5000000, help="Baud rate for the serial connection"
+    )
     parser.add_argument(
         "--frame-size", type=int, default=64, help="Number of bytes to read per frame"
     )


### PR DESCRIPTION
## Summary
- configure microcontroller serial port for 5 Mbps and adjust host receiver script
- document high-speed baud rate and wiring considerations
- confirm Teensy 4.x UART can handle 6 Mbaud

## Testing
- `python3 -m py_compile Scripts/serial_receiver.py`
- `g++ -c Scripts/main.cpp -o /tmp/main.o` *(fails: MQ8.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b0c079c4832894540b831dea1fc9