### PR TITLE
Add send/receive frequency diagnostics

### DIFF
--- a/Scripts/main.cpp
+++ b/Scripts/main.cpp
@@ -182,6 +182,17 @@ void sendSensorData() {
   interrupts();
 
   Serial.write(reinterpret_cast<uint8_t *>(&packet), sizeof(packet));
+
+  static uint32_t txCount = 0;
+  static uint32_t lastPrint = micros();
+  txCount++;
+  uint32_t now = micros();
+  if (now - lastPrint >= 1000000) {
+    float freq = (txCount * 1000000.0f) / (now - lastPrint);
+    Serial.printf("TX freq: %.2f Hz\n", freq);
+    txCount = 0;
+    lastPrint = now;
+  }
 }
 
 void setup() {

--- a/Scripts/serial_receiver.py
+++ b/Scripts/serial_receiver.py
@@ -1,15 +1,25 @@
 import argparse
 import serial
+import time
 
 
 def main(port: str, baudrate: int, frame_size: int) -> None:
     """Read fixed-size frames from the serial port and print them."""
     with serial.Serial(port, baudrate) as ser:
         buffer = bytearray(frame_size)
+        last_print = time.perf_counter()
+        frames = 0
         try:
             while True:
                 bytes_read = ser.readinto(buffer)
                 if bytes_read:
+                    frames += 1
+                    now = time.perf_counter()
+                    if now - last_print >= 1.0:
+                        freq = frames / (now - last_print)
+                        print(f"RX freq: {freq:.2f} Hz")
+                        frames = 0
+                        last_print = now
                     print(buffer[:bytes_read].decode("utf-8", errors="ignore"))
         except KeyboardInterrupt:
             pass


### PR DESCRIPTION
## Summary
- print Teensy transmission frequency once per second
- report measured RX rate in serial_receiver script

## Testing
- `python -m py_compile Scripts/serial_receiver.py`
- `g++ -fsyntax-only Scripts/main.cpp` *(fails: MQ8.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b484a2248328ab94cc26438351eb