### PR TITLE
Default to COM3 for serial receiver

### DIFF
--- a/Scripts/serial_receiver.py
+++ b/Scripts/serial_receiver.py
@@ -29,7 +29,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Receive and print sensor data from serial port"
     )
-    parser.add_argument("--port", default="/dev/ttyACM0", help="Serial port to open")
+    parser.add_argument(
+        "--port",
+        default="COM3",
+        help="Serial port to open (default: COM3)",
+    )
     parser.add_argument(
         "--baudrate", type=int, default=5000000, help="Baud rate for the serial connection"
     )


### PR DESCRIPTION
## Summary
- use COM3 as the default serial port for `serial_receiver.py`

## Testing
- `python -m py_compile Scripts/serial_receiver.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8963ceb648328b0a5afa8aa8c0b6f